### PR TITLE
buildエラーの解消

### DIFF
--- a/src/app/sample/[id]/error.tsx
+++ b/src/app/sample/[id]/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+
+// TODO: 仮のエラーページなので他でちゃんとしたものに置き換える
+const Error = ({ error }: { error: Error }) => {
+  useEffect(() => {
+    // 本来はホスティング先にLog出力するなどする
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }, [error]);
+
+  return <p>エラーページです。</p>;
+};
+
+export default Error;

--- a/src/app/sample/[id]/page.tsx
+++ b/src/app/sample/[id]/page.tsx
@@ -1,10 +1,10 @@
-import { Chef } from "@prisma/client";
+import { User } from "@prisma/client";
 
 import { ImageComponent } from "@/components/image";
 
 const RouteSamplePage = async ({ params }: { params: { id: string } }) => {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/chef/${params.id}`, { next: { revalidate: 1 } });
-  const chef: Chef = await res.json();
+  const chef: User = await res.json();
 
   return (
     <>

--- a/src/app/sample/error.tsx
+++ b/src/app/sample/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useEffect } from "react";
+
+// TODO: 仮のエラーページなので他でちゃんとしたものに置き換える
+const Error = ({ error }: { error: Error }) => {
+  useEffect(() => {
+    // 本来はホスティング先にLog出力するなどする
+    // eslint-disable-next-line no-console
+    console.error(error);
+  }, [error]);
+
+  return <p>エラーページです。</p>;
+};
+
+export default Error;


### PR DESCRIPTION
## チケット

closes #76 

<!-- issuesのリンクを記載 -->

## 内容
buildするとこけるので対応する。

### 原因
フェッチするページの同階層には必ずerror.tsxが無いといけないらしい。（エラーページはクライアントコンポーネント宣言が必須っぽい。詳しくは関連リンクをご覧ください。）
現状フェッチがされているのは/sample配下のみなのでerror.tsxを置いて対応。
中身はFE担当者にエラーコンポを作って貰う想定。

<!--　画像などを使いなるべくわかりやすく記載 -->

## 確認項目
ローカルにこちらのPRを落としていただき、buildがこけないか確かめていただきたいです。
その際下記のエラーが表示されますがスルーで問題ないです。（build自体は正常に通るはず）
```
Collecting page data ...Error: Invariant: Method expects to have requestAsyncStorage, none available
```
[バージョンを上げれば解決されるかもしれない](https://github.com/vercel/next.js/issues/46356)がcanaryを入れるのはリスキーなのでそのうち対応予定。

## 関連リンク
https://nextjs.org/docs/app/api-reference/file-conventions/error

## レビューを依頼する前のチェック項目

- [x] 要件を満たした
- [x] 要件を知らない人が見ても内容を理解できるように PR を書いた
- [x] 触った箇所以外も影響が出ていないか、想定内かを確認した
