### PR TITLE
ヘッダーのアイコンをクリックしたとき画面遷移するように変更

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,6 @@
+import { UrlObject } from "url";
+import Link from "next/link";
+
 import { IconArrowLeft, IconMenu, IconUserCircle } from "@tabler/icons-react";
 import cc from "classcat";
 
@@ -6,7 +9,7 @@ type Props = {
   addClassNames?: string;
   position?: "left" | "center";
   isUserIcon?: boolean;
-  isBrowserBackIcon?: boolean;
+  browserBackHref?: UrlObject;
   isMenuIcon?: boolean;
 };
 
@@ -21,11 +24,27 @@ export const Header: React.FC<Props> = (props) => {
   return (
     <div className={cc(["flex items-center justify-between border-b border-lightGray p-4", props.addClassNames])}>
       <div className="w-6">
-        {props.isBrowserBackIcon && <IconArrowLeft />}
-        {props.isMenuIcon && <IconMenu />}
+        {props.browserBackHref && (
+          <Link href={props.browserBackHref}>
+            <IconArrowLeft />
+          </Link>
+        )}
+        {props.isMenuIcon && (
+          // TODO: 設定ページに移動するが、まだ設定ページがなかったので修正する
+          <Link href={"/"}>
+            <IconMenu />
+          </Link>
+        )}
       </div>
       <h1 className={titleClass}>{props.title}</h1>
-      <div className="w-6">{props.isUserIcon && <IconUserCircle className="w-6" />}</div>
+      <div className="w-6">
+        {props.isUserIcon && (
+          // TODO: マイページに移動するが、まだマイページがなかったので修正する
+          <Link href={"/"}>
+            <IconUserCircle className="w-6" />
+          </Link>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -30,8 +30,7 @@ export const Header: React.FC<Props> = (props) => {
           </Link>
         )}
         {props.isMenuIcon && (
-          // TODO: 設定ページに移動するが、まだ設定ページがなかったので修正する
-          <Link href={"/"}>
+          <Link href={"/settings"}>
             <IconMenu />
           </Link>
         )}
@@ -39,8 +38,7 @@ export const Header: React.FC<Props> = (props) => {
       <h1 className={titleClass}>{props.title}</h1>
       <div className="w-6">
         {props.isUserIcon && (
-          // TODO: マイページに移動するが、まだマイページがなかったので修正する
-          <Link href={"/"}>
+          <Link href={"/fav/my"}>
             <IconUserCircle className="w-6" />
           </Link>
         )}


### PR DESCRIPTION
## チケット

closes #84 

## 内容

画面遷移をするようにLinkを使ったけど、マイページなどがまだなかったので、コメントで書いておきました。
左矢印のアイコンはページによって遷移先のページが違っていたので、どこに遷移するのかをpropsから渡すようにしました。


## レビューを依頼する前のチェック項目

- [x] 要件を満たした
- [x] 要件を知らない人が見ても内容を理解できるように PR を書いた
- [x] 触った箇所以外も影響が出ていないか、想定内かを確認した
