### PR TITLE
中間発表での表示を目的としてリダイレクトを設定

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,16 @@ const nextConfig = {
   images: {
     domains: ["ca.slack-edge.com", "images.unsplash.com", "ttkwelkbrvhyabgfiaia.supabase.co"],
   },
+    // 中間発表での表示を目的としてリダイレクトを設定
+  async redirects() {
+    return [
+      {
+        source: "/",
+        destination: "/search",
+        permanent: true,
+      },
+    ];
+  },
 };
 
 module.exports = nextConfig;

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,7 @@ import { NavLink } from "@/components/button";
 import { Icon } from "@/components/icon/Icon";
 
 const labels = [
-  { href: "/", label: "話題を検索", icon: <Icon type="Search" /> },
+  { href: "/search", label: "話題を検索", icon: <Icon type="Search" /> },
   { href: "/fav", label: "お気に入り", icon: <Icon type="Heart" /> },
   { href: "/list", label: "買い物リスト", icon: <Icon type="ShoppingCart" /> },
 ];


### PR DESCRIPTION
## チケット

closes #92 

<!-- issuesのリンクを記載 -->

## 内容
タイトルの通り。
ルートを表示させると/searchにリダイレクトされるように設定しました。
（Navigationの検索からも/searchを表示）

<!--　画像などを使いなるべくわかりやすく記載 -->

## 確認項目

## 関連リンク

## レビューを依頼する前のチェック項目

- [ ] 要件を満たした
- [ ] 要件を知らない人が見ても内容を理解できるように PR を書いた
- [ ] 触った箇所以外も影響が出ていないか、想定内かを確認した
