### PR TITLE
買い物リストページにHeaderコンポーネントを適用。セッション状態による表示切り替え処理も導入

### DIFF
--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -1,11 +1,10 @@
-import Image from "next/image";
-
 import { serverComponentSupabase } from "@/lib/serverComponentSupabase";
 import { MockMyList, MockRecipeList } from "@/mock";
 
 import { Header } from "@/components/Header/Header";
 import { ListShoppingHeader } from "@/components/list/ListShoppingHeader";
 import { ListShoppingItem } from "@/components/list/ListShoppingItem";
+import { Login } from "@/components/Login/Login";
 
 const ListPage = async () => {
   const {
@@ -14,7 +13,7 @@ const ListPage = async () => {
 
   return (
     <>
-      <Header position="center" title="買い物リスト" isMenuIcon={!!session} />
+      <Header position="center" title="買い物リスト" />
       {session ? (
         <div>
           <div>
@@ -35,20 +34,7 @@ const ListPage = async () => {
           </div>
         </div>
       ) : (
-        <div className="flex flex-col items-center">
-          <Image className="w-64" src="/images/sample_list.png" width="256" height="256" alt="" />
-          <p className="py-2 text-center font-bold">ログインをお願いします</p>
-          <p className="text-center text-medium">こちらの機能を利用するにはログインが必要です</p>
-          <div className="flex w-96 justify-between py-4">
-            <button className="w-44 rounded-xl  bg-blue p-2.5 font-bold text-white hover:opacity-80">
-              Google ログイン
-            </button>
-            <button className="w-44 rounded-xl  bg-black p-2.5 font-bold text-white hover:opacity-80">
-              Apple ログイン
-            </button>
-          </div>
-          <p className="text-center text-small">↑ cookiesを使ってログインっぽい挙動にしてます ↑</p>
-        </div>
+        <Login imageType="shopping" />
       )}
     </>
   );

--- a/src/app/list/page.tsx
+++ b/src/app/list/page.tsx
@@ -1,18 +1,21 @@
-import { NextPage } from "next";
 import Image from "next/image";
 
+import { serverComponentSupabase } from "@/lib/serverComponentSupabase";
 import { MockMyList, MockRecipeList } from "@/mock";
 
+import { Header } from "@/components/Header/Header";
 import { ListShoppingHeader } from "@/components/list/ListShoppingHeader";
 import { ListShoppingItem } from "@/components/list/ListShoppingItem";
 
-const Page: NextPage = () => {
-  const isLogin = true;
+const ListPage = async () => {
+  const {
+    data: { session },
+  } = await serverComponentSupabase.auth.getSession();
 
   return (
     <>
-      <p className="w-full border-b border-lightGray p-2 text-center font-bold">買い物リスト</p>
-      {isLogin ? (
+      <Header position="center" title="買い物リスト" isMenuIcon={!!session} />
+      {session ? (
         <div>
           <div>
             <ListShoppingHeader title="じぶんメモ" />
@@ -51,4 +54,4 @@ const Page: NextPage = () => {
   );
 };
 
-export default Page;
+export default ListPage;


### PR DESCRIPTION
## チケット

closes [#136](https://github.com/qin-team-recipe/10-recipe-app/issues/136)

## 内容

![スクリーンショット 2023-09-04 10 10 33](https://github.com/qin-team-recipe/10-recipe-app/assets/63841250/cd03ba8b-9990-4891-be66-161d07d64bcd)
issue発行時点では崩れていたレイアウトは、上図のとおり着手時点で解消されていました。
ただ、同じヘッダーを持っている買い物リストページでは、まだHeaderコンポーネントが使われていなかったためセッション状態による処理を含めて導入しました。

## 確認項目

・お気に入りレシピと同様に、買い物リストページのヘッダー部も適用されているか

## 関連リンク

なし

## レビューを依頼する前のチェック項目

- [x] 要件を満たした
- [x] 要件を知らない人が見ても内容を理解できるように PR を書いた
- [x] 触った箇所以外も影響が出ていないか、想定内かを確認した
