### PR TITLE
#165 HeaderコンポーネントのアイコンをIconコンポーネントに置き換え

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@prisma/client": "5",
     "@supabase/auth-helpers-nextjs": "^0.7.2",
     "@supabase/supabase-js": "^2.24.0",
-    "@tabler/icons-react": "^2.23.0",
     "next": "13.4.4",
     "prisma": "5",
     "react": "18.2.0",

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,8 +1,9 @@
 import { UrlObject } from "url";
 import Link from "next/link";
 
-import { IconArrowLeft, IconMenu, IconUserCircle } from "@tabler/icons-react";
 import cc from "classcat";
+
+import { Icon } from "@/components/Icon/Icon";
 
 type Props = {
   title: string;
@@ -26,12 +27,12 @@ export const Header: React.FC<Props> = (props) => {
       <div className="w-6">
         {props.browserBackHref && (
           <Link href={props.browserBackHref}>
-            <IconArrowLeft />
+            <Icon type="ArrowLeft" />
           </Link>
         )}
         {props.isMenuIcon && (
           <Link href="/settings">
-            <IconMenu />
+            <Icon type="Menu" />
           </Link>
         )}
       </div>
@@ -39,7 +40,7 @@ export const Header: React.FC<Props> = (props) => {
       <div className="w-6">
         {props.isUserIcon && (
           <Link href="/fav">
-            <IconUserCircle className="w-6" />
+            <Icon type="UserCircle" />
           </Link>
         )}
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3086,19 +3086,6 @@
   dependencies:
     tslib "^2.4.0"
 
-"@tabler/icons-react@^2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@tabler/icons-react/-/icons-react-2.23.0.tgz#c342ee171f289d8a18b6cd972bdc38181373bf28"
-  integrity sha512-+H4mC1EZVCzCRhnPwZEVTI0veVCJuAKlopeCnRlfsYcmzgJm6Ye234c4A2qrLPQoi1Y29uN9+kqCyuYW007jPg==
-  dependencies:
-    "@tabler/icons" "2.23.0"
-    prop-types "^15.7.2"
-
-"@tabler/icons@2.23.0":
-  version "2.23.0"
-  resolved "https://registry.yarnpkg.com/@tabler/icons/-/icons-2.23.0.tgz#8741d0bb6bd40696266489c3eb59f4c0c8c92f8d"
-  integrity sha512-dU54aBwaxG0H+jQ4BdrqtYFN5L7PZevvlnzyL6XeOZgfDS3+sVNCtuG3JmpTEqQSwGLYC1IEwogPGA/Iit2bOA==
-
 "@testing-library/dom@^9.0.0":
   version "9.3.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.1.tgz#8094f560e9389fb973fe957af41bf766937a9ee9"


### PR DESCRIPTION
## チケット

closes #165 

<!-- issuesのリンクを記載 -->

## 内容
ヘッダーのアイコンがtabler/icons-reactから呼ばれているのでアイコンコンポーネントに置き換える。
tabler/icons-reactPKGを削除する。

## 確認項目

## 関連リンク

## レビューを依頼する前のチェック項目

- [x] 要件を満たした
- [x] 要件を知らない人が見ても内容を理解できるように PR を書いた
- [x] 触った箇所以外も影響が出ていないか、想定内かを確認した
